### PR TITLE
Specify the ProtocolType dynamically

### DIFF
--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -143,7 +143,7 @@ mod tests {
                         ProtocolMessage::decode::<Bytes>(
                             ctx.advance(
                                 &(ProtocolMessage {
-                                    protocol_type: ProtocolType::Frost as i32,
+                                    protocol_type: Self::PROTOCOL_TYPE as i32,
                                     message: relay,
                                 })
                                 .encode_to_vec(),
@@ -234,7 +234,7 @@ mod tests {
                         ProtocolMessage::decode::<Bytes>(
                             ctx.advance(
                                 &(ProtocolMessage {
-                                    protocol_type: ProtocolType::Frost as i32,
+                                    protocol_type: Self::PROTOCOL_TYPE as i32,
                                     message: relay,
                                 })
                                 .encode_to_vec(),


### PR DESCRIPTION
I don't see a reason why the `ProtocolType` should be hardcoded for the modular test setup.