### PR TITLE
Refactor messages, distinguish broadcast and unicast

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "meesign-crypto"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/proto/meesign.proto
+++ b/proto/meesign.proto
@@ -21,13 +21,14 @@ message ProtocolInit {
   bytes data = 4;
 }
 
-enum MessageType {
-  UNICAST = 0;
-  BROADCAST = 1;
+message ClientMessage {
+  ProtocolType protocol_type = 1;
+  map<uint32, bytes> unicasts = 2;
+  optional bytes broadcast = 3;
 }
 
-message ProtocolMessage {
+message ServerMessage {
   ProtocolType protocol_type = 1;
-  MessageType message_type = 2;
-  repeated bytes messages = 3;
+  map<uint32, bytes> unicasts = 2;
+  map<uint32, bytes> broadcasts = 3;
 }

--- a/proto/meesign.proto
+++ b/proto/meesign.proto
@@ -21,7 +21,13 @@ message ProtocolInit {
   bytes data = 4;
 }
 
+enum MessageType {
+  UNICAST = 0;
+  BROADCAST = 1;
+}
+
 message ProtocolMessage {
   ProtocolType protocol_type = 1;
-  repeated bytes message = 2;
+  MessageType message_type = 2;
+  repeated bytes messages = 3;
 }

--- a/src/protocol/elgamal.rs
+++ b/src/protocol/elgamal.rs
@@ -107,7 +107,10 @@ impl KeygenContext {
                 }
                 let dkg = dkg.complete()?;
 
-                let msg = encode_raw_bcast(dkg.key_set().shared_key().as_bytes().to_vec(), ProtocolType::Elgamal);
+                let msg = encode_raw_bcast(
+                    dkg.key_set().shared_key().as_bytes().to_vec(),
+                    ProtocolType::Elgamal,
+                );
                 (KeygenRound::Done(dkg), msg)
             }
             KeygenRound::Done(_) => return Err("protocol already finished".into()),

--- a/src/protocol/elgamal.rs
+++ b/src/protocol/elgamal.rs
@@ -348,6 +348,8 @@ mod tests {
                 let (pks, _) =
                     <KeygenContext as KeygenProtocolTest>::run(threshold as u32, parties as u32);
 
+                let pks: Vec<_> = pks.into_values().collect();
+
                 for i in 1..parties {
                     assert_eq!(pks[0], pks[i])
                 }
@@ -361,13 +363,17 @@ mod tests {
             for parties in threshold..6 {
                 let (pks, ctxs) =
                     <KeygenContext as KeygenProtocolTest>::run(threshold as u32, parties as u32);
+                let pks: Vec<_> = pks.into_values().collect();
                 let msg = b"hello";
                 let ct = encrypt(msg, &pks[0]).unwrap();
 
-                let mut indices = (0..parties as u16).choose_multiple(&mut OsRng, threshold);
-                indices.sort();
+                let ctxs = ctxs
+                    .into_iter()
+                    .choose_multiple(&mut OsRng, threshold)
+                    .into_iter()
+                    .collect();
                 let results =
-                    <DecryptContext as ThresholdProtocolTest>::run(ctxs, indices, ct.to_vec());
+                    <DecryptContext as ThresholdProtocolTest>::run(ctxs, ct.to_vec());
 
                 for result in results {
                     assert_eq!(&msg.to_vec(), &result);

--- a/src/protocol/frost.rs
+++ b/src/protocol/frost.rs
@@ -21,6 +21,7 @@ struct Setup {
     index: u16,
 }
 
+/// Helper intended for use in `iterator.map`
 fn index_to_identifier<T>((i, x): (u32, T)) -> (Identifier, T) {
     assert!(i > 0);
     assert!(i <= u16::MAX as u32);

--- a/src/protocol/frost.rs
+++ b/src/protocol/frost.rs
@@ -369,7 +369,7 @@ mod tests {
 
                 let pks: Vec<VerifyingKey> = pks
                     .iter()
-                    .map(|x| serde_json::from_slice(&x).unwrap())
+                    .map(|(_, x)| serde_json::from_slice(&x).unwrap())
                     .collect();
 
                 for i in 1..parties {
@@ -386,12 +386,16 @@ mod tests {
                 let (pks, ctxs) =
                     <KeygenContext as KeygenProtocolTest>::run(threshold as u32, parties as u32);
                 let msg = b"hello";
-                let pk: VerifyingKey = serde_json::from_slice(&pks[0]).unwrap();
+                let (_, pk) = pks.iter().take(1).collect::<Vec<_>>()[0];
+                let pk: VerifyingKey = serde_json::from_slice(&pk).unwrap();
 
-                let mut indices = (0..parties as u16).choose_multiple(&mut OsRng, threshold);
-                indices.sort();
+                let ctxs = ctxs
+                    .into_iter()
+                    .choose_multiple(&mut OsRng, threshold)
+                    .into_iter()
+                    .collect();
                 let results =
-                    <SignContext as ThresholdProtocolTest>::run(ctxs, indices, msg.to_vec());
+                    <SignContext as ThresholdProtocolTest>::run(ctxs, msg.to_vec());
 
                 let signature: Signature = serde_json::from_slice(&results[0]).unwrap();
 

--- a/src/protocol/gg18.rs
+++ b/src/protocol/gg18.rs
@@ -21,6 +21,7 @@ enum KeygenRound {
     Done(GG18SignContext),
 }
 
+/// Collects a hashmap's values sorted by their respective keys
 fn map_to_sorted_vec<T>(map: HashMap<u32, T>) -> Vec<T> {
     let mut vec: Vec<_> = map.into_iter().collect();
     vec.sort_by_key(|(i, _)| *i);

--- a/src/protocol/gg18.rs
+++ b/src/protocol/gg18.rs
@@ -288,6 +288,8 @@ mod tests {
                 let (pks, _) =
                     <KeygenContext as KeygenProtocolTest>::run(threshold as u32, parties as u32);
 
+                let pks: Vec<_> = pks.into_values().collect();
+
                 for i in 1..parties {
                     assert_eq!(pks[0], pks[i])
                 }
@@ -304,12 +306,16 @@ mod tests {
                 let msg = b"hello";
                 let dgst = sha2::Sha256::digest(msg);
 
+                let pks: Vec<_> = pks.into_values().collect();
                 let pk = VerifyingKey::from_sec1_bytes(&pks[0]).unwrap();
 
-                let mut indices = (0..parties as u16).choose_multiple(&mut OsRng, threshold);
-                indices.sort();
+                let ctxs = ctxs
+                    .into_iter()
+                    .choose_multiple(&mut OsRng, threshold)
+                    .into_iter()
+                    .collect();
                 let results =
-                    <SignContext as ThresholdProtocolTest>::run(ctxs, indices, dgst.to_vec());
+                    <SignContext as ThresholdProtocolTest>::run(ctxs, dgst.to_vec());
 
                 let signature = results[0].clone();
 

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -68,8 +68,10 @@ fn encode_raw_uni(messages: Vec<Vec<u8>>, protocol_type: ProtocolType) -> Vec<u8
 
 /// Serialize and encode a Vec of unicast messages
 fn serialize_uni<T: Serialize>(vec: Vec<T>, protocol_type: ProtocolType) -> serde_json::Result<Vec<u8>> {
-    let messages: serde_json::Result<Vec<_>> = vec.iter().map(serde_json::to_vec).collect();
-    Ok(encode_raw_uni(messages?, protocol_type))
+    let messages = vec.iter()
+        .map(serde_json::to_vec)
+        .collect::<serde_json::Result<Vec<_>>>()?;
+    Ok(encode_raw_uni(messages, protocol_type))
 }
 
 /// Decode a protobuf message from the server

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -77,10 +77,11 @@ fn encode_raw_uni(messages: HashMap<u32, Vec<u8>>, protocol_type: ProtocolType) 
 /// Serialize and encode a map of unicast messages
 fn serialize_uni<T, I>(kvs: I, protocol_type: ProtocolType) -> serde_json::Result<Vec<u8>>
 where
-    I: Iterator<Item = (u32, T)>,
+    I: IntoIterator<Item = (u32, T)>,
     T: Serialize,
 {
     let messages = kvs
+        .into_iter()
         .map(|(k, v)| Ok((k, serde_json::to_vec(&v)?)))
         .collect::<serde_json::Result<_>>()?;
     Ok(encode_raw_uni(messages, protocol_type))

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -56,7 +56,10 @@ fn encode_raw_bcast(message: Vec<u8>, protocol_type: ProtocolType) -> Vec<u8> {
 }
 
 /// Serialize and encode a broadcast message
-fn serialize_bcast<T: Serialize>(value: &T, protocol_type: ProtocolType) -> serde_json::Result<Vec<u8>> {
+fn serialize_bcast<T: Serialize>(
+    value: &T,
+    protocol_type: ProtocolType,
+) -> serde_json::Result<Vec<u8>> {
     let message = serde_json::to_vec(value)?;
     Ok(encode_raw_bcast(message, protocol_type))
 }

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -37,6 +37,7 @@ pub trait ThresholdProtocol: Protocol {
         Self: Sized;
 }
 
+/// Deserializes values in a `HashMap`
 fn deserialize_map<'de, T: Deserialize<'de>>(
     map: &'de HashMap<u32, Vec<u8>>,
 ) -> serde_json::Result<HashMap<u32, T>> {
@@ -45,7 +46,7 @@ fn deserialize_map<'de, T: Deserialize<'de>>(
         .collect()
 }
 
-/// Encode a broadcast message
+/// Encode a broadcast message to protobuf format
 fn encode_raw_bcast(message: Vec<u8>, protocol_type: ProtocolType) -> Vec<u8> {
     ClientMessage {
         protocol_type: protocol_type.into(),
@@ -55,7 +56,7 @@ fn encode_raw_bcast(message: Vec<u8>, protocol_type: ProtocolType) -> Vec<u8> {
     .encode_to_vec()
 }
 
-/// Serialize and encode a broadcast message
+/// Serialize and encode a broadcast message to protobuf format
 fn serialize_bcast<T: Serialize>(
     value: &T,
     protocol_type: ProtocolType,
@@ -64,7 +65,9 @@ fn serialize_bcast<T: Serialize>(
     Ok(encode_raw_bcast(message, protocol_type))
 }
 
-/// Encode a Vec of unicast messages
+/// Encode unicast messages to protobuf format
+///
+/// Each message is associated with an index as used by a respective protocol
 fn encode_raw_uni(messages: HashMap<u32, Vec<u8>>, protocol_type: ProtocolType) -> Vec<u8> {
     ClientMessage {
         protocol_type: protocol_type.into(),
@@ -74,7 +77,9 @@ fn encode_raw_uni(messages: HashMap<u32, Vec<u8>>, protocol_type: ProtocolType) 
     .encode_to_vec()
 }
 
-/// Serialize and encode a map of unicast messages
+/// Serialize and encode unicast messages to protobuf format
+///
+/// Each message is associated with an index as used by a respective protocol
 fn serialize_uni<T, I>(kvs: I, protocol_type: ProtocolType) -> serde_json::Result<Vec<u8>>
 where
     I: IntoIterator<Item = (u32, T)>,


### PR DESCRIPTION
Replace sorted vectors with hashmaps, split `ProtocolMessage` into `ClientMessage` and `ServerMessage`, distinguish broadcast and unicast messages.